### PR TITLE
Support for wrap + sourcemaps

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1621,7 +1621,7 @@ define(function (require) {
             }
 
             //Write the built module to disk, and build up the build output.
-            fileContents = "";
+            fileContents = config.wrap ? config.wrap.start : "";
             return prim.serial(layer.buildFilePaths.map(function (path) {
                 return function () {
                     var lineCount,
@@ -1776,7 +1776,7 @@ define(function (require) {
                             }
 
                             sourceMapLineNumber = fileContents.split('\n').length - 1;
-                            
+
                             //Produce source maps for the flattened module based on
                             //JavaScript syntax elements.  This enables stepping
                             //through multiple statements per line, and is also
@@ -1852,9 +1852,7 @@ define(function (require) {
             });
         }).then(function () {
             return {
-                text: config.wrap ?
-                        config.wrap.start + fileContents + config.wrap.end :
-                        fileContents,
+                text: config.wrap ? fileContents + wrap.end : fileContents,
                 buildText: buildFileContents,
                 sourceMap: sourceMapGenerator ?
                               JSON.stringify(sourceMapGenerator.toJSON(), null, '  ') :

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1852,7 +1852,7 @@ define(function (require) {
             });
         }).then(function () {
             return {
-                text: config.wrap ? fileContents + wrap.end : fileContents,
+                text: config.wrap ? fileContents + config.wrap.end : fileContents,
                 buildText: buildFileContents,
                 sourceMap: sourceMapGenerator ?
                               JSON.stringify(sourceMapGenerator.toJSON(), null, '  ') :

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1574,6 +1574,8 @@ define(function (require) {
             sourceMapBase,
             buildFileContents = '';
 
+        var wrapStartText = config.wrap ? config.wrap.start + "\n" : "";
+
         return prim().start(function () {
             var reqIndex, currContents,
                 moduleName, shim, packageConfig, nonPackageName,
@@ -1621,7 +1623,7 @@ define(function (require) {
             }
 
             //Write the built module to disk, and build up the build output.
-            fileContents = config.wrap ? config.wrap.start : "";
+            fileContents = wrapStartText;
             return prim.serial(layer.buildFilePaths.map(function (path) {
                 return function () {
                     var lineCount,


### PR DESCRIPTION
### CHANGE SUMMARY
- wrap.start text would cause the source maps to be incorrect. Fixed this by updating the fileContents to this value (with a newline to ensure we do not need to update columns of mappings, only lines).
### CHANGE DETAILS
- in build.js the final output of flattenModule updated the text with the contents of config.wrap.start...however the sourcemaps were never updated.  The fix is to include that text prior to running the prim.serial code.
