### PR TITLE
Fix broken source maps

### DIFF
--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -461,7 +461,7 @@ function (lang,   logger,   envOptimize,        file,           parse,
                 } catch (e) {
                     throw new Error('Cannot uglify file: ' + fileName + '. Skipping it. Error is:\n' + e.toString());
                 }
-                return preamble + fileContents;
+                return fileContents;
             }
         }
     };


### PR DESCRIPTION
### GOAL

Fix Hadron's broken source maps.  This fix is for situations where `generateSourceMaps` and `preserveLicenseComments` are both set, in which case comments are being doubled in the resulting source file.

I've opened https://github.com/requirejs/r.js/issues/964 against upstream for them to look at, but in the meantime, this fix will get Hadron source maps working for v12.0.

### TESTS

- [x] All tests pass locally (this situation isn't caught by current tests.  I could write one, and potentially submit back to upstream, but I am waiting for a maintainer to indicate whether this is the appropriate fix long-term).